### PR TITLE
[Fix] 샷건, 폭발성 무기 격발 위치 포구 옆방향에서 앞방향으로 변경

### DIFF
--- a/Assets/JGH/Scripts/BarrelWeapon.cs
+++ b/Assets/JGH/Scripts/BarrelWeapon.cs
@@ -19,7 +19,8 @@ public class BarrelWeapon : BaseWeapon
         for (int i = 0; i < pelletCount; i++)
         {
             float angle = startAngle + angleStep * i;
-            Quaternion spreadRotation = firingPoint.rotation * Quaternion.Euler(0, 0, angle);
+            
+            Quaternion spreadRotation = firingPoint.rotation * Quaternion.Euler(0, 0, angle - 90); 
             Vector3 spawnPos = firingPoint.position + firingPoint.right * 0.2f;
 
             Instantiate(bulletPrefab, spawnPos, spreadRotation);

--- a/Assets/JGH/Scripts/ExplosiveBulletWeapon.cs
+++ b/Assets/JGH/Scripts/ExplosiveBulletWeapon.cs
@@ -10,7 +10,7 @@ public class ExplosiveBulletWeapon : BaseWeapon
     {
         if (isReloading || currentAmmo <= 0 || Time.time - lastAttackTime < attackCooldown) return;
 
-        Instantiate(bulletPrefab, firingPoint.position, firingPoint.rotation * Quaternion.Euler(0, 0, 90f));
+        Instantiate(bulletPrefab, firingPoint.position, firingPoint.rotation * Quaternion.Euler(0, 0, -90f));
 
         currentAmmo--;
         lastAttackTime = Time.time;


### PR DESCRIPTION
# 📌 Pull Request
## ✨ 작업 내용
- 샷건, 폭발성 무기 격발 위치 포구 옆방향에서 앞방향으로 변경

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?

