### PR TITLE
[Fix] PoolManager Destory 버그 수정

### DIFF
--- a/Assets/SDW/Scripts/Manager/PoolManager.cs
+++ b/Assets/SDW/Scripts/Manager/PoolManager.cs
@@ -23,7 +23,7 @@ public class PoolManager : MonoBehaviour, IPunPrefabPool
             _pools[prefabId] = new ObjectPool<GameObject>(
                 () =>
                 {
-                    var newGameObject = Instantiate(prefab);
+                    var newGameObject = GameObject.Instantiate(prefab);
 
                     if (newGameObject.GetComponent<PhotonView>() == null)
                         newGameObject.AddComponent<PhotonView>();
@@ -32,7 +32,7 @@ public class PoolManager : MonoBehaviour, IPunPrefabPool
                 },
                 obj => obj.SetActive(true),
                 obj => obj.SetActive(false),
-                obj => Destroy(obj),
+                obj => GameObject.Destroy(obj),
                 true,
                 defaultCapacity,
                 maxSize


### PR DESCRIPTION
## ✨ 작업 내용
- 작업한 내용, 변경 사항 간략히 설명
- GameObject의 Destroy 대신 PoolManager의 Destroy가 호출되는 문제 수정
  - PoolManager의 Destroy가 호출되면 Max Pool Size를 넘어도 파괴되지 않는 문제가 발생함
  - GameObject의 Destory를 호출하여 Max Pool Size를 넘으면 오브젝트가 파괴되도록 수정

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?
