### PR TITLE
[Feat] 맵 생성 로직 수정 및 UI 디자인/버그 수정 및 테스트 완료

### DIFF
--- a/Assets/LHW/Scene/MapLoadingSystem/LHW_MapCreateSystemTest 2.unity
+++ b/Assets/LHW/Scene/MapLoadingSystem/LHW_MapCreateSystemTest 2.unity
@@ -663,6 +663,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1034312562}
   - {fileID: 756873452}
   - {fileID: 1296535538}
   m_Father: {fileID: 310302810}
@@ -1297,6 +1298,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   mapChangeDelay: 0.8
+  rounds:
+  - {fileID: 744652833}
+  - {fileID: 686892225}
+  - {fileID: 1670197}
 --- !u!1 &607417151
 GameObject:
   m_ObjectHideFlags: 0
@@ -1403,108 +1408,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 624789507}
   m_CullTransparentMesh: 1
---- !u!1 &654997274
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 654997278}
-  - component: {fileID: 654997277}
-  - component: {fileID: 654997276}
-  - component: {fileID: 654997275}
-  m_Layer: 5
-  m_Name: CardScene
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &654997275
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654997274}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &654997276
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654997274}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &654997277
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654997274}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &654997278
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 654997274}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1428593495}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
 --- !u!1 &658697389
 GameObject:
   m_ObjectHideFlags: 0
@@ -1600,6 +1503,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1115319945}
+  - {fileID: 1894761145}
   - {fileID: 152872340}
   - {fileID: 1533162509}
   - {fileID: 1899245634}
@@ -1623,6 +1528,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   creator: {fileID: 1416241614}
+  cardSelectPanel: {fileID: 1115319944}
   roundOverPanel: {fileID: 1533162508}
   gameRestartPanel: {fileID: 1899245633}
   roundOverPanelDuration: 3
@@ -2134,6 +2040,81 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1416241615}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1034312561
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1034312562}
+  - component: {fileID: 1034312564}
+  - component: {fileID: 1034312563}
+  m_Layer: 5
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1034312562
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034312561}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 184093941}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 1178.0098, y: -36.64148}
+  m_SizeDelta: {x: 201.1342, y: 167.5205}
+  m_Pivot: {x: 6.18, y: 0.5}
+--- !u!114 &1034312563
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034312561}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1034312564
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1034312561}
+  m_CullTransparentMesh: 1
 --- !u!1 &1052363874
 GameObject:
   m_ObjectHideFlags: 0
@@ -2226,6 +2207,82 @@ RectTransform:
   m_AnchoredPosition: {x: 80, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1115319944
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1115319945}
+  - component: {fileID: 1115319947}
+  - component: {fileID: 1115319946}
+  m_Layer: 5
+  m_Name: TestCardScene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1115319945
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1115319944}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1272400198}
+  m_Father: {fileID: 658697393}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1115319946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1115319944}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1115319947
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1115319944}
+  m_CullTransparentMesh: 1
 --- !u!1 &1116787917
 GameObject:
   m_ObjectHideFlags: 0
@@ -2490,6 +2547,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1266607908}
   m_CullTransparentMesh: 1
+--- !u!1 &1272400197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1272400198}
+  - component: {fileID: 1272400200}
+  - component: {fileID: 1272400199}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1272400198
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272400197}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1115319945}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1272400199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272400197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Card Scene Test Ver Panel
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 80
+  m_fontSizeBase: 80
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1272400200
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1272400197}
+  m_CullTransparentMesh: 1
 --- !u!1 &1296535537
 GameObject:
   m_ObjectHideFlags: 0
@@ -2622,81 +2813,6 @@ Transform:
   - {fileID: 975357395}
   m_Father: {fileID: 1629229710}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1428593494
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1428593495}
-  - component: {fileID: 1428593497}
-  - component: {fileID: 1428593496}
-  m_Layer: 5
-  m_Name: CardScene
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1428593495
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428593494}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 654997278}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1428593496
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428593494}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1428593497
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428593494}
-  m_CullTransparentMesh: 1
 --- !u!1 &1450967070
 GameObject:
   m_ObjectHideFlags: 0
@@ -3146,6 +3262,7 @@ MonoBehaviour:
   - {fileID: 1815037346}
   - {fileID: 0}
   losePosition: {fileID: 1756198263}
+  sceneChangeInitTransform: {fileID: 1894761145}
   roundImageShrinkDuration: 0.1
   winImageShrinkDuration: 0.1
   winImageShrinkDelay: 1.6
@@ -3858,6 +3975,41 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1893796501}
   m_CullTransparentMesh: 1
+--- !u!1 &1894761144
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1894761145}
+  m_Layer: 5
+  m_Name: SceneChangePanelInit
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1894761145
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1894761144}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 658697393}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 2020, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1899245633
 GameObject:
   m_ObjectHideFlags: 0
@@ -4392,4 +4544,3 @@ SceneRoots:
   - {fileID: 1713404349}
   - {fileID: 184912394}
   - {fileID: 471775424}
-  - {fileID: 654997278}

--- a/Assets/LHW/Scripts/GameSystem/MapSystem/MapController.cs
+++ b/Assets/LHW/Scripts/GameSystem/MapSystem/MapController.cs
@@ -1,6 +1,6 @@
-using UnityEngine;
 using DG.Tweening;
 using System.Collections;
+using UnityEngine;
 
 /// <summary>
 /// 생성된 랜덤 3개의 맵이 한 게임 종료 후 이동하게 하는 스크립트
@@ -10,6 +10,8 @@ public class MapController : MonoBehaviour
     [Header("Offset")]
     [Tooltip("맵 전환 시작 딜레이")]
     [SerializeField] private float mapChangeDelay = 0.8f;
+
+    [SerializeField] private GameObject[] rounds;
     public float MapChangeDelay { get { return mapChangeDelay; } }
 
     private Coroutine moveCoroutine;
@@ -17,11 +19,13 @@ public class MapController : MonoBehaviour
     private void OnEnable()
     {
         TestIngameManager.OnRoundOver += GoToNextStage;
+        TestIngameManager.onCardSelectEnd += MapMove;
     }
 
     private void OnDisable()
     {
         TestIngameManager.OnRoundOver -= GoToNextStage;
+        TestIngameManager.onCardSelectEnd -= MapMove;
     }
 
     public void GoToNextStage()
@@ -44,14 +48,20 @@ public class MapController : MonoBehaviour
     private void MapMove()
     {
         Debug.Log("실행");
-        moveCoroutine = StartCoroutine(MovementCoroutine());
+        if (!TestIngameManager.Instance.IsCardSelectTime)
+        {
+            moveCoroutine = StartCoroutine(MovementCoroutine());
+        }
     }
 
     IEnumerator MovementCoroutine()
     {
         WaitForSeconds delay = new WaitForSeconds(mapChangeDelay);
 
-        MapDynamicMovement[] movements = GetComponentsInChildren<MapDynamicMovement>();
+        MapDynamicMovement[] movements = rounds[TestIngameManager.Instance.CurrentGameRound].GetComponentsInChildren<MapDynamicMovement>();
+
+        Debug.Log(movements);
+
         for (int i = 0; i < movements.Length; i++)
         {
             if (movements[i] != null)
@@ -60,6 +70,7 @@ public class MapController : MonoBehaviour
                 yield return delay;
             }
         }
+
         moveCoroutine = null;
     }
 }

--- a/Assets/LHW/Scripts/GameSystem/MapSystem/MapDynamicMovement.cs
+++ b/Assets/LHW/Scripts/GameSystem/MapSystem/MapDynamicMovement.cs
@@ -20,9 +20,6 @@ public class MapDynamicMovement : MonoBehaviour
     {
         mapController = GetComponentInParent<MapController>();
         randomMapPresetCreator = GetComponentInParent<RandomMapPresetCreator>();
-
-        Debug.Log(mapController);
-        Debug.Log(randomMapPresetCreator);
     }
 
     public void DynamicMove()

--- a/Assets/LHW/Scripts/GameSystem/MapSystem/MapDynamicMovement.cs
+++ b/Assets/LHW/Scripts/GameSystem/MapSystem/MapDynamicMovement.cs
@@ -15,11 +15,14 @@ public class MapDynamicMovement : MonoBehaviour
     [SerializeField] float moveDelay = 1f;
     // 각 플랫폼이 이동하기 시작하는 간격
     [SerializeField] float moveDurationOffset = 0.2f;
-
-    private void OnEnable()
+    
+    private void Start()
     {
         mapController = GetComponentInParent<MapController>();
         randomMapPresetCreator = GetComponentInParent<RandomMapPresetCreator>();
+
+        Debug.Log(mapController);
+        Debug.Log(randomMapPresetCreator);
     }
 
     public void DynamicMove()

--- a/Assets/LHW/Scripts/GameSystem/MapSystem/RandomMapPresetCreator.cs
+++ b/Assets/LHW/Scripts/GameSystem/MapSystem/RandomMapPresetCreator.cs
@@ -55,7 +55,6 @@ public class RandomMapPresetCreator : MonoBehaviour
     public void MapUpdate(int round)
     {
         if (TestIngameManager.Instance.IsGameOver) return;
-        Debug.Log(round);
         mapListTransform[round - 1].gameObject.SetActive(false);
         mapListTransform[round].gameObject.SetActive(true);
     }

--- a/Assets/LHW/Scripts/GameSystem/MapSystem/RandomMapPresetCreator.cs
+++ b/Assets/LHW/Scripts/GameSystem/MapSystem/RandomMapPresetCreator.cs
@@ -54,6 +54,7 @@ public class RandomMapPresetCreator : MonoBehaviour
 
     public void MapUpdate(int round)
     {
+        if (TestIngameManager.Instance.IsGameOver) return;
         Debug.Log(round);
         mapListTransform[round - 1].gameObject.SetActive(false);
         mapListTransform[round].gameObject.SetActive(true);

--- a/Assets/LHW/Scripts/GameSystem/TestManager/TestIngameManager.cs
+++ b/Assets/LHW/Scripts/GameSystem/TestManager/TestIngameManager.cs
@@ -145,7 +145,6 @@ public class TestIngameManager : MonoBehaviour
             GameSetOver("Left");
             currentGameRound++;
         }
-        Debug.Log(winner);
         OnRoundOver?.Invoke();
     }
 

--- a/Assets/LHW/Scripts/GameSystem/TestManager/TestIngameManager.cs
+++ b/Assets/LHW/Scripts/GameSystem/TestManager/TestIngameManager.cs
@@ -27,10 +27,14 @@ public class TestIngameManager : MonoBehaviour
 
     #endregion
 
+    public static event Action onCardSelectEnd;
     public static event Action OnRoundOver;
     public static event Action OnGameSetOver;
     public static event Action OnGameOver;
     public static event Action OnSkillObtained;
+
+    private bool isCardSelectTime = false;
+    public bool IsCardSelectTime { get {  return isCardSelectTime; } } 
 
     private bool isRoundOver = false;
     private bool isGameSetOver = false;
@@ -57,13 +61,15 @@ public class TestIngameManager : MonoBehaviour
         playerRoundScore.Add("Right", 0);
         playerGameScore.Add("Left", 0);
         playerGameScore.Add("Right", 0);
+        GameStart();
     }
 
     void Update()
     {
         if(Input.GetKeyDown(KeyCode.Q))
         {
-            // 카드 셀렉팅 종료
+            CardSelectEnd();
+            RoundStart();
         }
 
         // 테스트용 코드
@@ -101,6 +107,7 @@ public class TestIngameManager : MonoBehaviour
 
     public void GameStart()
     {
+        isCardSelectTime = true;
         isRoundOver = false;
         isGameSetOver = false;
         isGameOver = false;
@@ -109,6 +116,12 @@ public class TestIngameManager : MonoBehaviour
         playerGameScore["Left"] = 0;
         playerGameScore["Right"] = 0;
         currentGameRound = 0;
+    }
+
+    public void CardSelectEnd()
+    {
+        isCardSelectTime = false;
+        onCardSelectEnd?.Invoke();
     }
 
     public void RoundStart()
@@ -150,7 +163,8 @@ public class TestIngameManager : MonoBehaviour
     private void GameSetOver(string winner)
     {
         isGameSetOver = true;
-        playerGameScore[winner] += 1;        
+        isCardSelectTime = true;
+        playerGameScore[winner] += 1;
         currentWinner = winner;
         OnGameSetOver?.Invoke();
         if (playerGameScore["Left"] >= 2 || playerGameScore["Right"] >= 2)
@@ -163,12 +177,6 @@ public class TestIngameManager : MonoBehaviour
     {
         isGameOver = true;
         OnGameOver?.Invoke();        
-    }
-
-    public void SceneChange()
-    {
-        // TODO : 카드 선택 씬으로 전환
-        Debug.Log("Scene Change");
     }
 
     #region TestCode - Card

--- a/Assets/LHW/Scripts/GameSystem/UI/IngameUIManager.cs
+++ b/Assets/LHW/Scripts/GameSystem/UI/IngameUIManager.cs
@@ -28,12 +28,14 @@ public class IngameUIManager : MonoBehaviour
     {
         TestIngameManager.OnRoundOver += RoundOverPanelShow;
         TestIngameManager.OnGameOver += RestartPanelShow;
+        TestIngameManager.onCardSelectEnd += HideCardSelectPanel;
     }
 
     private void OnDisable()
     {
         TestIngameManager.OnRoundOver -= RoundOverPanelShow;
         TestIngameManager.OnGameOver -= RestartPanelShow;
+        TestIngameManager.onCardSelectEnd -= HideCardSelectPanel;
     }
 
     private void RoundOverPanelShow()
@@ -56,6 +58,11 @@ public class IngameUIManager : MonoBehaviour
         gameRestartPanel.SetActive(false);
     }
 
+    private void HideCardSelectPanel()
+    {
+        cardSelectPanel.SetActive(false);
+    }
+
     /// <summary>
     /// 라운드 종료 패널을 활성화하고 지속시간만큼 유지한 다음 다시 비활성화하는 코루틴
     /// </summary>
@@ -73,6 +80,10 @@ public class IngameUIManager : MonoBehaviour
             Debug.Log("새 세트 시작");
             creator.MapUpdate(TestIngameManager.Instance.CurrentGameRound);
             TestIngameManager.Instance.GameSetStart();
+            if (!TestIngameManager.Instance.IsGameOver)
+            {
+                cardSelectPanel.SetActive(true);
+            }
         }
 
         ROPanelCoroutine = null;

--- a/Assets/LHW/Scripts/GameSystem/UI/RoundOverPanelController.cs
+++ b/Assets/LHW/Scripts/GameSystem/UI/RoundOverPanelController.cs
@@ -1,4 +1,5 @@
 using DG.Tweening;
+using System.Collections;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -27,6 +28,7 @@ public class RoundOverPanelController : MonoBehaviour
     [SerializeField] private Transform[] leftImageWinSpot;
     [SerializeField] private Transform[] rightImageWinSpot;
     [SerializeField] private Transform losePosition;
+    [SerializeField] private Transform sceneChangeInitTransform;
 
     [Header("Offset")]
     [Tooltip("매 라운드마다 나타난 승리 횟수 이미지가 줄어드는 데 걸리는 시간")]
@@ -44,6 +46,8 @@ public class RoundOverPanelController : MonoBehaviour
     Color textColor;
     string leftTextColor = "#FF8400";
     string rightTextColor = "#009EFF";
+
+    Coroutine sceneChangeCoroutine;
 
     private void OnEnable()
     {
@@ -77,14 +81,14 @@ public class RoundOverPanelController : MonoBehaviour
     /// <param name="right"></param>
     private void TextInit(string winner, int left, int right)
     {
-        if(winner == "Left")
+        if (winner == "Left")
         {
             if (ColorUtility.TryParseHtmlString(leftTextColor, out textColor))
             {
                 winnerText.color = textColor;
             }
 
-            if(left == 1)
+            if (left == 1)
             {
                 winnerText.text = "Half Orange";
             }
@@ -118,22 +122,22 @@ public class RoundOverPanelController : MonoBehaviour
     /// <param name="right"></param>
     private void ImageInit(int left, int right)
     {
-        if(left == 0) leftFillImage.fillAmount = 0;
+        if (left == 0) leftFillImage.fillAmount = 0;
         else leftFillImage.fillAmount = (float)left / 2;
-        
-        if(right == 0) rightFillImage.fillAmount = 0;
+
+        if (right == 0) rightFillImage.fillAmount = 0;
         else rightFillImage.fillAmount = (float)right / 2;
-    
-        if(left == 2)
+
+        if (left == 2)
         {
-            sceneChangePanel.transform.DOMove(transform.position, 1f).SetDelay(1f);
             AddScoreAnimation(leftImage);
+            SceneChange();
             return;
         }
-        else if(right == 2)
+        else if (right == 2)
         {
-            sceneChangePanel.transform.DOMove(transform.position, 1f).SetDelay(1f);
-            AddScoreAnimation(rightImage);
+            AddScoreAnimation(leftImage);
+            SceneChange();
             return;
         }
 
@@ -193,5 +197,23 @@ public class RoundOverPanelController : MonoBehaviour
             leftImage.transform.DOMove(losePosition.position, winImageShrinkDuration).SetDelay(winnerImageMoveTime);
             leftImage.transform.DOScale(new Vector3(loseImageExpansionScale, loseImageExpansionScale, loseImageExpansionScale), winImageShrinkDuration).SetDelay(winnerImageMoveTime + 0.3f);
         }
+    }
+
+    private void SceneChange()
+    {
+        sceneChangeCoroutine = StartCoroutine(SceneChangeCoroutine());
+    }
+
+    IEnumerator SceneChangeCoroutine()
+    {
+        WaitForSeconds delay = new WaitForSeconds(3f);
+
+        sceneChangePanel.transform.DOMove(transform.position, 1f).SetDelay(1f);
+        yield return delay;
+        if (!TestIngameManager.Instance.IsGameOver)
+        {
+            sceneChangePanel.transform.position = sceneChangeInitTransform.position;
+        }
+        sceneChangeCoroutine = null;
     }
 }

--- a/Assets/LHW/Scripts/GameSystem/UI/RoundOverPanelController.cs
+++ b/Assets/LHW/Scripts/GameSystem/UI/RoundOverPanelController.cs
@@ -152,7 +152,6 @@ public class RoundOverPanelController : MonoBehaviour
     private void AddScoreAnimation(Image winnerImage)
     {
         string currentWinner = TestIngameManager.Instance.ReadRoundScore(out int leftScore, out int rightScore);
-        Debug.Log(leftScore);
         if (currentWinner == "Left")
         {
             leftImage.transform.DOScale(new Vector3(0.13f, 0.13f, 0.13f), winImageShrinkDuration).SetDelay(winImageShrinkDelay);

--- a/Assets/LHW/Scripts/GameSystem/UI/StaticScoreUI.cs
+++ b/Assets/LHW/Scripts/GameSystem/UI/StaticScoreUI.cs
@@ -80,23 +80,18 @@ public class StaticScoreUI : MonoBehaviour
         if (currentWinner == "Left")
         {
             leftWinImages[leftWinNum - 1].transform.DOScale(new Vector3(2.5f, 2.5f, 2.5f), 0.1f).SetDelay(scoreObtainDelay);
-            if (rightRoundNum == 1 && rightWinImages[rightRoundNum - 1].activeSelf)
+            if (rightRoundNum == 1 && rightWinImages[rightWinNum].activeSelf)
             {
-                rightWinImages[rightRoundNum - 1].SetActive(false);
+                rightWinImages[rightWinNum].SetActive(false);
             }
         }
         else if (currentWinner == "Right")
         {
             rightWinImages[rightWinNum - 1].transform.DOScale(new Vector3(2.5f, 2.5f, 2.5f), 0.1f).SetDelay(scoreObtainDelay);
-            if (leftRoundNum == 1 && leftWinImages[leftWinNum - 1].activeSelf)
+            if (leftRoundNum == 1 && leftWinImages[leftWinNum].activeSelf)
             {
-                leftWinImages[leftWinNum - 1].SetActive(false);
+                leftWinImages[leftWinNum].SetActive(false);
             }
-        }
-
-        if (leftWinNum != 3 && rightWinNum != 3)
-        {
-            TestIngameManager.Instance.SceneChange();
         }
     }
 }

--- a/Assets/LHW/Scripts/Objects/Rope/RopeFreeze.cs
+++ b/Assets/LHW/Scripts/Objects/Rope/RopeFreeze.cs
@@ -16,11 +16,13 @@ public class RopeFreeze : MonoBehaviour
     private void OnEnable()
     {
         TestIngameManager.OnRoundOver += FreezeRope;
+        TestIngameManager.onCardSelectEnd += FreezeRope;
     }
 
     private void OnDisable()
     {
         TestIngameManager.OnRoundOver -= FreezeRope;
+        TestIngameManager.onCardSelectEnd -= FreezeRope;
     }
 
     private void FreezeRope()


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업 내용
- 맵 생성 로직 수정, UI 디자인 및 게임 판 수 수정 작업(2/2)
- UI관련 버그 수정 및 디자인 변경

## 🎥 스크린샷 / 영상 (선택)

https://github.com/user-attachments/assets/63d8a457-d121-449a-9e06-1b16029009fa

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?

---

## 📝 기타 참고사항 (선택)
- 테스트 해 보신다고 실행하실 때, Q를 누르면 카드 선택 종료 상황으로 가정 - 첫 번째 맵이 이동합니다. 이후 E가 왼쪽 승리 R이 오른쪽 승리로 점수 계산이 시작됩니다. 상황에 맞게 눌러줘야지 정확히 작동합니다
- 혹시나 실행 중에 맵의 대열이 틀어지거나 로프가 늘어지는 게 보이면, 그건 버그가 아니라 너무 빨리 실행해서 생기는 틀어짐입니다... 맵이 완전히 로딩되기 전에 너무 빨리 실행하면 생기는 문제이며 실제 게임 작동 상황에는 반영되지 않을 버그로 보입니다(카드 선택 단계에서 맵이 로딩되고 있기 때문에 플레이어가 카드를 살피지도 않고 바로 선택해버리는 거 아니면 발생하지 않음 암튼 버그 아님)