### PR TITLE
[Fix] 게임 재시작 UI에서 리매치 거부 시 로비로 돌아가지 않는 현상 해결

### DIFF
--- a/Assets/LHW/Scripts/GameSystem/UI/GameRestartPanelController.cs
+++ b/Assets/LHW/Scripts/GameSystem/UI/GameRestartPanelController.cs
@@ -1,5 +1,7 @@
+using System.Data;
 using System.Linq;
 using Photon.Pun;
+using Photon.Realtime;
 using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -11,6 +13,8 @@ public class GameRestartPanelController : MonoBehaviourPunCallbacks
     [SerializeField] Button noButton;
     [SerializeField] TMP_Text winnerText;
     [SerializeField] TMP_Text waitingText;
+
+    private bool isLeaving = false;
 
     private void Awake()
     {
@@ -65,16 +69,21 @@ public class GameRestartPanelController : MonoBehaviourPunCallbacks
 
     private void EndGame()
     {
+        if (isLeaving) return;
+        isLeaving = true;
+
         Debug.Log("방에나감.");
+        SceneManager.LoadScene("USW/LobbyScene/LobbyScene");
+        SoundManager.Instance.PlayBGMLoop("MainMenuLoop");
         PhotonNetwork.LeaveRoom();
-        gameObject.SetActive(false);
+
     }
 
     public override void OnLeftRoom()
     {
-        SceneManager.LoadScene("LobbyScene");
-        SoundManager.Instance.PlayBGMLoop("MainMenuLoop");
+        Debug.Log("씬 전환");
     }
+
 
     //#  20250809 추가사항
     private string GetPlayerNickName(string actorNumberString)

--- a/Assets/USW/GameScene/Ingame/InGameManager.cs
+++ b/Assets/USW/GameScene/Ingame/InGameManager.cs
@@ -646,11 +646,14 @@ public class InGameManager : MonoBehaviourPunCallbacks, IPunObservable
         bool allVoted = true;
         bool allAgree = true;
 
+
         foreach (var kvp in rematchVotes)
         {
             if (!kvp.Value)
             {
                 allAgree = false;
+                photonView.RPC("RPC_RematchDeclined", RpcTarget.All);
+                break;
             }
         }
 
@@ -673,6 +676,7 @@ public class InGameManager : MonoBehaviourPunCallbacks, IPunObservable
     [PunRPC]
     private void RPC_RematchDeclined()
     {
+        CardManager.Instance.ClearLists();
         isWaitingForRematch = false;
         OnRematchRequest?.Invoke(false);
         Debug.Log("리매치 거부됨");


### PR DESCRIPTION
# 📌 Pull Request

## ✨ 작업 내용
- 게임 재시작 UI에서 리매치 거부 시 로비로 돌아가지 않는 현상 해결

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?