### PR TITLE
[Fix] 퀵 리로드일 때 애니매이션 한바퀴돌고 4/1 더 도는 문제 해결

### DIFF
--- a/Assets/JGH/Scripts/BaseWeapon.cs
+++ b/Assets/JGH/Scripts/BaseWeapon.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using Photon.Pun;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -109,8 +110,21 @@ public abstract class BaseWeapon : MonoBehaviourPunCallbacks, IWeapon, IPunObser
     {
         // float speed = 2f / reloadTime / 2; // 애니메이션 속도 계산
         // Debug.Log($"CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed : {CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed}");
-        float speed = 2f / CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed / 2; // 애니메이션 속도 계산
+        // float speed += 2f / CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed / 2; // 애니메이션 속도 계산
+        float speed = (2f / CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed / 2); // 애니메이션 속도 계산
 
+        int i = 0;
+        int count = CardManager.Instance.GetLists().Count;
+        List<CardBase> cardList = CardManager.Instance.GetLists();
+        do
+        {
+            if (cardList[i].CardName == "QUICK RELOAD")
+            {
+                speed *= 1.7f; // 애니메이션 속도 계산
+            }
+
+            i++;
+        } while (i > count);
 
         if (PhotonNetwork.OfflineMode)
         {


### PR DESCRIPTION
# 📌 Pull Request
## ✨ 작업 내용
- 퀵 리로드일 때 애니매이션 한바퀴돌고 4/1 더 도는 문제 해결

## ✅ PR 체크리스트
- [ ] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [ ] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?

