### PR TITLE
[Fix] 레이저 상대가 퀵 리로드 먹으면 레이저에도 퀵리로드가 적용되는 문제 해결

### DIFF
--- a/Assets/JGH/Scripts/BaseWeapon.cs
+++ b/Assets/JGH/Scripts/BaseWeapon.cs
@@ -40,6 +40,8 @@ public abstract class BaseWeapon : MonoBehaviourPunCallbacks, IWeapon, IPunObser
 
     private Vector3 _networkPosition;
     private Quaternion _networkRotation;
+    
+    protected virtual bool ApplyQuickReload => true;
 
     protected PoolManager _poolManager;
     // protected CardManager cardManager;
@@ -108,24 +110,30 @@ public abstract class BaseWeapon : MonoBehaviourPunCallbacks, IWeapon, IPunObser
     /// </summary>
     protected void ReloadSpeedFromAnimator()
     {
-        // float speed = 2f / reloadTime / 2; // 애니메이션 속도 계산
-        // Debug.Log($"CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed : {CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed}");
-        // float speed += 2f / CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed / 2; // 애니메이션 속도 계산
         float speed = 2f / CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed / 2; // 애니메이션 속도 계산
 
-        int i = 0;
-        int count = CardManager.Instance.GetLists().Count;
-        var cardList = CardManager.Instance.GetLists();
-
-        while (i < count)
+        // 무기 타입으로 레이저 예외 처리
+        if (GetWeaponType() == WeaponType.Laser)
         {
-            if (cardList[i].CardName == "QUICK RELOAD")
-            {
-                speed *= 1.7f; // 애니메이션 속도 계산
-            }
-
-            i++;
+            // 레이저는 퀵리로드 영향 없음 (필요시 상수 조절)
+            SetAnimatorSingleSpeed(0.333f);
+            return;
         }
+
+        // 레이저 외 무기만 퀵리로드 적용
+        if (ApplyQuickReload)
+        {
+            int count = CardManager.Instance.GetLists().Count;
+            var cardList = CardManager.Instance.GetLists();
+            for (int i = 0; i <count; i++)
+            {
+                if (cardList[i].CardName == "QUICK RELOAD")
+                {
+                    speed *= 1.7f;
+                }
+            }
+        }
+
 
         if (PhotonNetwork.OfflineMode)
         {

--- a/Assets/JGH/Scripts/LaserWeapon.cs
+++ b/Assets/JGH/Scripts/LaserWeapon.cs
@@ -12,6 +12,7 @@ public class LaserWeapon : BaseWeapon
     private bool isFiring = false;
     private WeaponType weaponType = WeaponType.Laser;
    
+    protected override bool ApplyQuickReload => false;
 
     public override void Attack(Transform firingPoint)
     {
@@ -91,7 +92,7 @@ public class LaserWeapon : BaseWeapon
         yield return new WaitForSeconds(laserDuration);
 
         isFiring = false;
-        StartAutoReload();
+        // StartAutoReload();
 
         // 레이저 정리
         if (currentLaserInstance != null)
@@ -109,10 +110,12 @@ public class LaserWeapon : BaseWeapon
         // 애니메이션 트리거 실행
         animator?.SetTrigger("Reload");
 
-        yield return null;
-        ReloadSpeedFromAnimator();
+        // yield return null;
+        SetAnimatorSingleSpeed(0.333f);
+        //ReloadSpeedFromAnimator();
         // yield return new WaitForSeconds(reloadTime);
-        yield return new WaitForSeconds(CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed);
+        // yield return new WaitForSeconds(CardManager.Instance.GetCaculateCardStats().DefaultReloadSpeed);
+        yield return new WaitForSeconds(3f);
 
         // currentAmmo = maxAmmo;
         currentAmmo = (int)CardManager.Instance.GetCaculateCardStats().DefaultAmmo;


### PR DESCRIPTION
# 📌 Pull Request
## ✨ 작업 내용
- 레이저 상대가 퀵 리로드 먹으면 레이저에도 퀵리로드가 적용되는 문제 해결
## ✅ PR 체크리스트
- [ ] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [ ] 불필요한 로그/주석/테스트 코드 제거했는가?
- [ ] 기능 테스트 및 정상 동작을 확인했는가?