### PR TITLE
[Fix] 폭발탄 데미지 여러번 들어가던 오류 수정, OutArea가 싱글에서 데미지를 주던 오류 수정

### DIFF
--- a/Assets/KDJ/Scripts/ExplosiveBullet.cs
+++ b/Assets/KDJ/Scripts/ExplosiveBullet.cs
@@ -1,25 +1,29 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using Photon.Pun;
 using Unity.Mathematics;
 using UnityEngine;
 
-public class ExplosiveBullet : MonoBehaviour
+public class ExplosiveBullet : MonoBehaviourPun
 {
     private Collider2D[] _colls = new Collider2D[20];
+    private int _count = 0;
 
     private void Start()
     {
         ExplosionShock();
-        SoundManager.Instance.PlaySFX("ExplosionSound"+ UnityEngine.Random.Range(1, 3));
+        SoundManager.Instance.PlaySFX("ExplosionSound" + UnityEngine.Random.Range(1, 3));
         CameraShake.Instance.ShakeCaller(0.65f, 0.1f);
     }
 
     public void ExplosionShock()
     {
+        Array.Clear(_colls, 0, _colls.Length); // Clear the array before use
         // Radius는 폭발 범위
         int count = Physics2D.OverlapCircleNonAlloc(transform.position, 1f, _colls);
 
-        if (count > 0)
+        if (count > 0 && photonView.IsMine)
         {
             for (int i = 0; i < count; i++)
             {
@@ -43,6 +47,7 @@ public class ExplosiveBullet : MonoBehaviour
                     // 6f은 피해량. 이후 스텟 최종 피해량으로 변경 필요
                     float damage = 0.5f / distance.sqrMagnitude;
                     damage = Mathf.Clamp(damage, 0.1f, 3f); // 최소 0.1, 최대 3으로 제한
+                    Debug.Log($"폭발 데미지 : {damage}, 호출 시간 : {Time.time}");
                     damagable.TakeDamage(damage, hitPosition, hitNormal);
                 }
             }

--- a/Assets/KDJ/Scripts/ExplosiveBullet.cs
+++ b/Assets/KDJ/Scripts/ExplosiveBullet.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Photon.Pun;
-using Unity.Mathematics;
 using UnityEngine;
 
 public class ExplosiveBullet : MonoBehaviourPun
@@ -47,7 +44,6 @@ public class ExplosiveBullet : MonoBehaviourPun
                     // 6f은 피해량. 이후 스텟 최종 피해량으로 변경 필요
                     float damage = 0.5f / distance.sqrMagnitude;
                     damage = Mathf.Clamp(damage, 0.1f, 3f); // 최소 0.1, 최대 3으로 제한
-                    Debug.Log($"폭발 데미지 : {damage}, 호출 시간 : {Time.time}");
                     damagable.TakeDamage(damage, hitPosition, hitNormal);
                 }
             }

--- a/Assets/KDJ/Scripts/TestCode/TestOutArea.cs
+++ b/Assets/KDJ/Scripts/TestCode/TestOutArea.cs
@@ -1,7 +1,9 @@
 using System.Collections;
 using System.Collections.Generic;
 using Photon.Pun;
+using UnityEditor.SearchService;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class TestOutArea : MonoBehaviourPun
 {
@@ -28,7 +30,7 @@ public class TestOutArea : MonoBehaviourPun
                         var effectL = Instantiate(_borderEffect, collision.transform.position, Quaternion.identity);
                         effectL.transform.LookAt(collision.transform.position + Vector3.right);
                         rb2d.AddForce(Vector2.right * 20f, ForceMode2D.Impulse);
-                        if (PhotonNetwork.OfflineMode || !playerPhotonView.IsMine) break;
+                        if (SceneManager.GetActiveScene().name == "KDJ_WeaponTestScene" || !playerPhotonView.IsMine) break;
                         // Debug.Log("경계면 데미지 호출");
                         damagable.TakeDamage(6, collision.transform.position, Vector2.right);
                         break;
@@ -36,7 +38,7 @@ public class TestOutArea : MonoBehaviourPun
                         var effectR = Instantiate(_borderEffect, collision.transform.position, Quaternion.identity);
                         effectR.transform.LookAt(collision.transform.position + Vector3.left);
                         rb2d.AddForce(Vector2.left * 20f, ForceMode2D.Impulse);
-                        if (PhotonNetwork.OfflineMode || !playerPhotonView.IsMine) break;
+                        if (SceneManager.GetActiveScene().name == "KDJ_WeaponTestScene" || !playerPhotonView.IsMine) break;
                         // Debug.Log("경계면 데미지 호출");
                         damagable.TakeDamage(6, collision.transform.position, Vector2.left);
                         break;
@@ -49,7 +51,7 @@ public class TestOutArea : MonoBehaviourPun
                         var effectD = Instantiate(_borderEffect, collision.transform.position, Quaternion.identity);
                         effectD.transform.LookAt(collision.transform.position + Vector3.up);
                         rb2d.AddForce(Vector2.up * 20f, ForceMode2D.Impulse);
-                        if (PhotonNetwork.OfflineMode || !playerPhotonView.IsMine) break;
+                        if (SceneManager.GetActiveScene().name == "KDJ_WeaponTestScene" || !playerPhotonView.IsMine) break;
                         // Debug.Log("경계면 데미지 호출");
                         damagable.TakeDamage(6, collision.transform.position, Vector2.up);
                         break;

--- a/Assets/KDJ/Scripts/TestCode/TestOutArea.cs
+++ b/Assets/KDJ/Scripts/TestCode/TestOutArea.cs
@@ -1,7 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
 using Photon.Pun;
-using UnityEditor.SearchService;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 


### PR DESCRIPTION
# 📌 Pull Request
## ✨ 작업 내용
- 폭발탄 계산시 배열을 비우지 않아 이전에 담겨있던 플레이어에 데미지가 들어가는 버그 수정했습니다.
- OutArea의 데미지 예외 처리가 Offline으로만 설정되어 있어 현재씬이 WeaponTestScene일때 예외 처리하도록 수정했습니다.

---

## ✅ PR 체크리스트
- [x] 이슈 번호에 `resolves:` 또는 `related to:`를 정확히 작성했는가?
- [x] 불필요한 로그/주석/테스트 코드 제거했는가?
- [x] 기능 테스트 및 정상 동작을 확인했는가?